### PR TITLE
Türen von und zum Engelraum repariert

### DIFF
--- a/church.json
+++ b/church.json
@@ -37,7 +37,7 @@
                 {
                  "name":"exitUrl",
                  "type":"string",
-                 "value":"\/schaarserella\/ash-roedemis\/gh-pages\/room1.json"
+                 "value":"room1.json"
                 }],
          "type":"tilelayer",
          "visible":true,

--- a/room1.json
+++ b/room1.json
@@ -19,7 +19,7 @@
                 {
                  "name":"exitUrl",
                  "type":"string",
-                 "value":"\/schaarserella\/ash-roedemis\/gh-pages\/church.json#exit_room1"
+                 "value":"church.json#exit_room1"
                 }],
          "type":"tilelayer",
          "visible":true,


### PR DESCRIPTION
exitUrls zu room1.json und zurück sind absolute Pfade. Die funktioniren aber im neuen WA-Release anscheinend nichtmehr richtig.